### PR TITLE
Verify artifacts with cosign before auto-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ with Docker and Kubernetes KIND in under five minutes.
 
 This project spins up a Docker Registry container named `kind-registry` and a Kubernetes Kind cluster
 named `flux` under the same Docker network. Then it installs Flux and configures it to upgrade itself
-from the latest OCI artifact published at `ghcr.io/fluxcd/flux-manifests`.
+from the latest OCI artifact published at `ghcr.io/fluxcd/flux-manifests`. Before an upgrade, Flux
+verifies that the OCI artifacts are signed by the Flux team with Cosign and GitHub OIDC.
 
 | Component                                                                                                | Role                            | Host                        |
 |----------------------------------------------------------------------------------------------------------|---------------------------------|-----------------------------|

--- a/kubernetes/clusters/local/flux-system/flux-source.yaml
+++ b/kubernetes/clusters/local/flux-system/flux-source.yaml
@@ -10,4 +10,6 @@ spec:
   ref:
     tag: latest
   url: oci://ghcr.io/fluxcd/flux-manifests
-  insecure: true
+  verify:
+    provider: cosign
+

--- a/kubernetes/clusters/local/flux-system/flux-sync.yaml
+++ b/kubernetes/clusters/local/flux-system/flux-sync.yaml
@@ -50,16 +50,3 @@ spec:
       target:
         kind: Namespace
         name: flux-system
-    - patch: |
-        - op: add
-          path: /spec/template/spec/containers/0/env/-
-          value:
-            name: TUF_ROOT
-            value: "/tmp/.sigstore"
-      target:
-        kind: Deployment
-        name: "source-controller"
-#  images:
-#    - name: ghcr.io/fluxcd/source-controller
-#      newName: localhost:5050/source-controller
-#      newTag: rc15


### PR DESCRIPTION
Configure Flux auto-upgrade to verify that the OCI artifacts are signed by the Flux team with Cosign and GitHub OIDC.