### PR TITLE
Use kube-prometheus-stack signed OCI Helm chart

### DIFF
--- a/kubernetes/infra/controllers/prometheus-operator.yaml
+++ b/kubernetes/infra/controllers/prometheus-operator.yaml
@@ -13,7 +13,8 @@ metadata:
   namespace: monitoring
 spec:
   interval: 120m
-  url: https://prometheus-community.github.io/helm-charts
+  type: oci
+  url: oci://ghcr.io/prometheus-community/charts
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
@@ -24,11 +25,13 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: "35.x"
+      version: "41.x"
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
+      verify:
+        provider: cosign
       interval: 60m
   install:
     crds: Create


### PR DESCRIPTION
Changes:
- Pull kube-prometheus-stack from `oci://ghcr.io/prometheus-community/charts`
- Enable Cosign verification for the kube-prometheus-stack Helm release
