### PR TITLE
Update OCI paths for Flux v0.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ make tools
 ```
 
 The complete list of tools can be found in the `Brewfile`.
+Note that the minimum required version of Flux is v0.38.2.
 
 ### Bootstrap
 
@@ -443,16 +444,6 @@ spec:
     - name: ghcr.io/fluxcd/source-controller
       newName: localhost:5050/source-controller
       newTag: oci1
-  patches:
-    - patch: |
-        - op: add
-          path: /spec/template/spec/containers/0/env/-
-          value:
-            name: TUF_ROOT
-            value: "/tmp/.sigstore"
-      target:
-        kind: Deployment
-        name: "source-controller"
 ```
 
 Sync the changes on the cluster with `make sync` and wait for the new version to rollout:

--- a/kubernetes/clusters/local/apps.yaml
+++ b/kubernetes/clusters/local/apps.yaml
@@ -23,7 +23,7 @@ spec:
   interval: 1h
   retryInterval: 30s
   timeout: 5m
-  path: ./kubernetes/apps
+  path: ./
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/kubernetes/clusters/local/flux-system/cluster-sync.yaml
+++ b/kubernetes/clusters/local/flux-system/cluster-sync.yaml
@@ -10,7 +10,7 @@ spec:
   interval: 1h
   retryInterval: 1m
   timeout: 5m
-  path: ./kubernetes/clusters/local
+  path: ./
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/kubernetes/clusters/local/infra.yaml
+++ b/kubernetes/clusters/local/infra.yaml
@@ -21,7 +21,7 @@ spec:
   interval: 1h
   retryInterval: 1m
   timeout: 5m
-  path: ./kubernetes/infra/controllers
+  path: ./controllers
   prune: true
   wait: true
   sourceRef:
@@ -39,7 +39,7 @@ spec:
   interval: 1h
   retryInterval: 1m
   timeout: 5m
-  path: ./kubernetes/infra/config
+  path: ./config
   prune: true
   sourceRef:
     kind: OCIRepository


### PR DESCRIPTION
Starting with Flux v0.38, the OCI artifacts no longer include the full path given to `flux push`.