### PR TITLE
Enable Helm drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make tools
 ```
 
 The complete list of tools can be found in the `Brewfile`.
-Note that the minimum required version of Flux is v0.38.2.
+Note that the minimum required version of Flux is v0.41.0.
 
 ### Bootstrap
 

--- a/kubernetes/clusters/local/flux-system/flux-sync.yaml
+++ b/kubernetes/clusters/local/flux-system/flux-sync.yaml
@@ -68,13 +68,10 @@ spec:
     - patch: |
         - op: add
           path: /spec/template/spec/containers/0/args/-
-          value: --feature-gates=DetectDrift=true
+          value: --feature-gates=DetectDrift=true,OOMWatch=true
         - op: replace
           path: /spec/template/spec/containers/0/args/2
           value: --log-level=debug
       target:
         kind: Deployment
         name: "(helm-controller)"
-  images:
-    - name: ghcr.io/fluxcd/helm-controller
-      newTag: rc-0bfbc3ee

--- a/kubernetes/clusters/local/flux-system/flux-sync.yaml
+++ b/kubernetes/clusters/local/flux-system/flux-sync.yaml
@@ -65,3 +65,16 @@ spec:
       target:
         kind: Namespace
         name: flux-system
+    - patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --feature-gates=DetectDrift=true
+        - op: replace
+          path: /spec/template/spec/containers/0/args/2
+          value: --log-level=debug
+      target:
+        kind: Deployment
+        name: "(helm-controller)"
+  images:
+    - name: ghcr.io/fluxcd/helm-controller
+      newTag: rc-0bfbc3ee

--- a/kubernetes/infra/controllers/prometheus-operator.yaml
+++ b/kubernetes/infra/controllers/prometheus-operator.yaml
@@ -54,6 +54,24 @@ spec:
         podMonitorSelector:
           matchLabels:
             app.kubernetes.io/component: monitoring
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              # Ignore these objects from Flux diff as they are mutated from chart hooks
+              kind: (ValidatingWebhookConfiguration|MutatingWebhookConfiguration)
+              name: kube-prometheus-stack-admission
+            patch: |
+              - op: add
+                path: /metadata/annotations/helm.toolkit.fluxcd.io~1diff
+                value: disabled
+          - target:
+              # Ignore these objects from Flux diff as they are mutated at apply time but not at dry-run time
+              kind: PrometheusRule
+            patch: |
+              - op: add
+                path: /metadata/annotations/helm.toolkit.fluxcd.io~1diff
+                value: disabled
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/kubernetes/infra/controllers/prometheus-operator.yaml
+++ b/kubernetes/infra/controllers/prometheus-operator.yaml
@@ -60,14 +60,14 @@ spec:
               name: kube-prometheus-stack-admission
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1diff
+                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
                 value: disabled
           - target:
               # Ignore these objects from Flux diff as they are mutated at apply time but not at dry-run time
               kind: PrometheusRule
             patch: |
               - op: add
-                path: /metadata/annotations/helm.toolkit.fluxcd.io~1diff
+                path: /metadata/annotations/helm.toolkit.fluxcd.io~1driftDetection
                 value: disabled
 ---
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/infra/controllers/prometheus-operator.yaml
+++ b/kubernetes/infra/controllers/prometheus-operator.yaml
@@ -13,8 +13,7 @@ metadata:
   namespace: monitoring
 spec:
   interval: 120m
-  type: oci
-  url: oci://ghcr.io/prometheus-community/charts
+  url: https://prometheus-community.github.io/helm-charts
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
@@ -25,13 +24,11 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: "41.x"
+      version: "45.x"
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      verify:
-        provider: cosign
       interval: 60m
   install:
     crds: Create


### PR DESCRIPTION
Enable Helm drift detection and ignore objects which are mutated behind the door (e.g. jobs that run `kubectl patch` in kube-prom-stack).