### PR TITLE
Update APIs to Flux v2.0.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ make tools
 ```
 
 The complete list of tools can be found in the `Brewfile`.
-Note that the minimum required version of Flux is v0.41.0.
+
+Note that the minimum required version of Flux is `v2.0.0-rc.1`.
 
 ### Bootstrap
 
@@ -200,7 +201,7 @@ spec:
     tag: local
   url: oci://kind-registry:5000/flux-cue-apps-sync
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cue-apps-sync
@@ -272,7 +273,7 @@ From within the flux-local-dev clone, open the `kubernetes/clusters/local/flux-s
 and add an image patch:
 
 ```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-sync
@@ -434,7 +435,7 @@ Open the `kubernetes/clusters/local/flux-system/flux-sync.yaml` file
 and patch the controller deployment with the local image:
 
 ```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-sync

--- a/kubernetes/clusters/local/apps.yaml
+++ b/kubernetes/clusters/local/apps.yaml
@@ -12,7 +12,7 @@ spec:
     tag: local
   url: oci://kind-registry:5000/flux-apps-sync
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: apps-sync

--- a/kubernetes/clusters/local/flux-system/cluster-sync.yaml
+++ b/kubernetes/clusters/local/flux-system/cluster-sync.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-sync

--- a/kubernetes/clusters/local/flux-system/flux-sync.yaml
+++ b/kubernetes/clusters/local/flux-system/flux-sync.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-sync

--- a/kubernetes/clusters/local/infra.yaml
+++ b/kubernetes/clusters/local/infra.yaml
@@ -12,7 +12,7 @@ spec:
     tag: local
   url: oci://kind-registry:5000/flux-infra-sync
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-controllers
@@ -28,7 +28,7 @@ spec:
     kind: OCIRepository
     name: infra-source
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-config

--- a/kubernetes/infra/config/flux-monitoring.yaml
+++ b/kubernetes/infra/config/flux-monitoring.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: flux-monitoring
@@ -10,7 +10,7 @@ spec:
   ref:
     branch: main
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-monitoring


### PR DESCRIPTION
Changes:
- Update GitRepository and Kustomization APIs to `v1`.
- Set the minimum required version of Flux to `v2.0.0-rc.1`.