### PR TITLE
Fix a false positive difference in `scripts/flux/push.sh`

### DIFF
--- a/scripts/flux/push.sh
+++ b/scripts/flux/push.sh
@@ -9,6 +9,7 @@ diff_push() {
   artifact_name=$1
   artifact_path=$2
 
+  diff_exit_code=0
   flux diff artifact oci://${artifact_name} \
     --path="${artifact_path}" &>/dev/null || diff_exit_code=$?
 


### PR DESCRIPTION
The function `diff_push` is called 3 times in `scripts/flux/push.sh`.
If a call detects a difference, subsequent calls will still upload an artifact even if there is no difference found.

So, `diff_exit_code` should be reset for subsequent calls.